### PR TITLE
Remove white space from JSON while sharing to reduce link length

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ function App() {
   useEffect(() => {
     if (benchmarkFromRequest) {
       try {
-        setRawInput(benchmarkFromRequest);
+        setRawInput(JSON.stringify(JSON.parse(benchmarkFromRequest), null, 2));
       } catch (e) {
         console.error(e);
       }
@@ -200,7 +200,7 @@ function App() {
                 <Button
                   onClick={() => {
                     const url = new URL(window.location.href);
-                    url.searchParams.set("benchmarks", rawInput ?? "");
+                    url.searchParams.set("benchmarks", JSON.stringify(JSON.parse(rawInput ?? "")));
                     url.searchParams.set(
                       "filters",
                       JSON.stringify(filter) ?? ""


### PR DESCRIPTION
Fixes #22

Minify JSON when creating sharable link and pretty print JSON when reading from query params.

* **Minify JSON when creating sharable link**
  - Update `src/App.tsx` to minify the JSON when creating the sharable link on line 199.
* **Pretty print JSON when reading from query params**
  - Update `src/App.tsx` to pretty print the JSON when reading from the query params on line 37.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yogeshpaliyal/benchmarkify/issues/22?shareId=bfaf193a-511b-41f2-9af4-efb41c39924a).